### PR TITLE
ObraDinnAPWorld: fix client argument parsing to support launcher CLI args

### DIFF
--- a/worlds/obra_dinn/__init__.py
+++ b/worlds/obra_dinn/__init__.py
@@ -10,9 +10,9 @@ from .subclasses import Character
 from ..LauncherComponents import launch_subprocess, components, Component, Type
 
 
-def launch_client():
+def launch_client(*args):
     from .client import launch
-    launch_subprocess(launch, name="ObraDinnClient")
+    launch_subprocess(launch, name="ObraDinnClient",args=args))
 
 
 components.append(

--- a/worlds/obra_dinn/client.py
+++ b/worlds/obra_dinn/client.py
@@ -250,10 +250,10 @@ async def proxy_loop(ctx: ObraDinnContext):
         logger.info("Aborting ObraDinn Proxy Client due to errors")
 
 
-def launch():
+def launch(*launch_args):
     async def main():
         parser = get_base_parser()
-        args = parser.parse_args()
+        args = parser.parse_args(launch_args)
 
         ctx = ObraDinnContext(args.connect, args.password)
         logger.info("Starting Return of the Obra Dinn proxy server")


### PR DESCRIPTION
## What is this fixing or adding?

This PR fixes how the Obra Dinn client handles command-line arguments passed from the Archipelago launcher.
Previously, the client used parser.parse_args(), which raises errors when unknown arguments (like the component name) are passed via CLI. This broke launching Obra Dinn through the command line interface.

The fix mirrors others by:

Adding *args to the launch_client function to accept arbitrary CLI args.

Passing those args explicitly to launch_subprocess.

Modifying the launch function in client.py to accept *launch_args and passing those into parser.parse_args().

This change allows the Obra Dinn client to gracefully accept and ignore unknown launcher arguments while still receiving the known parameters it needs, resolving the CLI launch errors


## How was this tested?

Made these changes on a local AP install and verified the game launches successfully via both GUI and CLI methods, including when extra arguments like component names are passed.

Confirmed no argument parsing errors occur